### PR TITLE
Develop (#26)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,19 @@
 History
 =======
 
+0.0.6 (2018-04-06)
+------------------
+Raise useful errors from the api calls so they are returned to the calling app
+
+
+0.0.5
+-----
+Tests
+Service helpers
+
+0.0.4
+-----
+
 0.0.3 (2018-04-03)
 ------------------
 Store token for 4 hours (issue #7)

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,13 +1,7 @@
-Modules
-=======
+royal_mail_rest_api
+===================
 
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: royal_mail_rest_api.api
-    :members:
-
-.. automodule:: royal_mail_rest_api.tracking
-    :members:
-
-.. automodule:: royal_mail_rest_api.shipping
-    :members:
-
+   royal_mail_rest_api

--- a/docs/royal_mail_rest_api.rst
+++ b/docs/royal_mail_rest_api.rst
@@ -1,0 +1,70 @@
+royal\_mail\_rest\_api package
+==============================
+
+Submodules
+----------
+
+royal\_mail\_rest\_api.api module
+---------------------------------
+
+.. automodule:: royal_mail_rest_api.api
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+royal\_mail\_rest\_api.errors module
+------------------------------------
+
+.. automodule:: royal_mail_rest_api.errors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+royal\_mail\_rest\_api.example module
+-------------------------------------
+
+.. automodule:: royal_mail_rest_api.example
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+royal\_mail\_rest\_api.get\_credentials module
+----------------------------------------------
+
+.. automodule:: royal_mail_rest_api.get_credentials
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+royal\_mail\_rest\_api.shipping module
+--------------------------------------
+
+.. automodule:: royal_mail_rest_api.shipping
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+royal\_mail\_rest\_api.tools module
+-----------------------------------
+
+.. automodule:: royal_mail_rest_api.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+royal\_mail\_rest\_api.tracking module
+--------------------------------------
+
+.. automodule:: royal_mail_rest_api.tracking
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: royal_mail_rest_api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/royal_mail_rest_api/__init__.py
+++ b/royal_mail_rest_api/__init__.py
@@ -4,7 +4,8 @@
 
 __author__ = """Alex Hellier"""
 __email__ = 'alex.hellier@gmail.com'
-__version__ = '0.0.5'
+__version__ = '0.0.6'
+
 
 
 # from .api import RoyalMailBaseClass

--- a/royal_mail_rest_api/errors.py
+++ b/royal_mail_rest_api/errors.py
@@ -4,3 +4,6 @@ class NotAuthorised(Exception):
 
 class GeneralError(Exception):
     pass
+
+class RoyalMailError(Exception):
+    pass

--- a/royal_mail_rest_api/example.py
+++ b/royal_mail_rest_api/example.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     body.add_service_type('royal_mail_tracked')
     body.add_service_format('inland_large_letter')
     body.add_service_offering('royal_mail_tracked_24')
-    body.add_service_enhancements('e-mail_notification')
+    body.add_service_enhancements('sms_and_e-mail_notification')
     body.add_service_occurence()
     body.add_signature()
     body.customer_reference = 'D123456'
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     body.sender_reference = 'A123456'
     body.add_items(1, 100, 'g')
     body.add_receipient_contact('Joe Bloggs', 'joe.bloggs@royalmail.com', None, '07970810000')
-    body.add_receipient_address('Broadgate Circle', 'London', None, 'EC1A 1BB', country='GB', building_number='1',
+    body.add_receipient_address('Broadgate Circle', 'London', None, 'BH10 6JJ', country='GB', building_number='1',
                                 address_line2='Add line 2', address_line3='Add line 3', building_name='My building')
 
     # Request our body to use to request a label from royal mail

--- a/royal_mail_rest_api/shipping.py
+++ b/royal_mail_rest_api/shipping.py
@@ -1,7 +1,7 @@
 import requests
 import datetime
 from royal_mail_rest_api.api import RoyalMailBaseClass
-
+from royal_mail_rest_api.errors import RoyalMailError
 
 
 class ShippingApi(RoyalMailBaseClass):
@@ -76,6 +76,17 @@ class ShippingApi(RoyalMailBaseClass):
             self.token_created = datetime.datetime.now()
             self._create_token_header()
 
+    def _error_handler(self, result):
+        """
+        Deal with returning a useful error up the chain, not just an http response error for the client app to deal with.
+        :param result:
+        :return:
+        """
+        try:
+            result.raise_for_status()
+        except Exception:
+            raise RoyalMailError(result.json())
+
 
     def post_domestic(self, data):
         """
@@ -94,7 +105,7 @@ class ShippingApi(RoyalMailBaseClass):
         self.get_token()
         data = data
         result = requests.post('{}{}'.format(self.url, self.post_domestic_url), json=data, headers=self.tokenheader)
-        result.raise_for_status()
+        self._error_handler(result)
         return result.json()
 
     def put_shipment(self, shipment_number, data):
@@ -116,7 +127,7 @@ class ShippingApi(RoyalMailBaseClass):
         self.get_token()
         result = requests.put('{}{}{}'.format(self.url, self.put_shipment_update_url, shipment_number), json=data,
                               headers=self.tokenheader)
-        result.raise_for_status()
+        self._error_handler(result)
         return result.json()
 
     def delete_shipment(self, shipment_number):
@@ -130,7 +141,7 @@ class ShippingApi(RoyalMailBaseClass):
         self.get_token()
         result = requests.delete('{}{}{}'.format(self.url, self.delete_shipment_url, shipment_number),
                                  headers=self.tokenheader)
-        result.raise_for_status()
+        self._error_handler(result)
         return result.json()
 
     def put_shipment_label(self, shipment_number):
@@ -145,7 +156,7 @@ class ShippingApi(RoyalMailBaseClass):
         self.get_token()
         result = requests.put('{}{}{}/label'.format(self.url, self.put_shipment_label_url, shipment_number),
                               headers=self.tokenheader)
-        result.raise_for_status()
+        self._error_handler(result)
         return result.json()
 
     def post_manifest(self, manifest_options=None):
@@ -160,7 +171,7 @@ class ShippingApi(RoyalMailBaseClass):
         self.get_token()
         result = requests.post('{}{}'.format(self.url, self.post_manifest_url), json=manifest_options,
                                headers=self.tokenheader)
-        result.raise_for_status()
+        self._error_handler(result)
         return result.json()
 
     def put_manifest(self, sales_order_number=None, manifest_batch_number=None):
@@ -181,5 +192,5 @@ class ShippingApi(RoyalMailBaseClass):
 
         result = requests.put('{}{}?{}'.format(self.url, self.post_manifest_url, query_params),
                               headers=self.tokenheader)
-        result.raise_for_status()
+        self._error_handler(result)
         return result.json()

--- a/royal_mail_rest_api/tools.py
+++ b/royal_mail_rest_api/tools.py
@@ -165,6 +165,7 @@ class RoyalMailBody:
         self.item_count = len(self.items)
         self.safe_place = None
         self.enhancements = []
+
     def return_domestic_body(self):
         """
         build domestic body from items
@@ -218,6 +219,11 @@ class RoyalMailBody:
         return new_dict
 
     def _check_ship_type(self, shipment_type):
+        """
+        Check that the shipment type is valid (currently only delivery)
+        :param shipment_type:
+        :return:
+        """
         if shipment_type.lower() != 'delivery':
             # TODO: Find out the other options here!
             raise ValueError('Sorry, only delivery supported at the moment')
@@ -239,7 +245,10 @@ class RoyalMailBody:
             raise(TypeError('Sorry, need a datetime object'))
 
     def _add_service(self):
-
+        """
+        create our service block from already added inputs
+        :return:
+        """
         service = {
             "format": self.service_format,
             "occurrence": self.service_occurence,
@@ -252,6 +261,11 @@ class RoyalMailBody:
         return service
 
     def add_service_format(self, format=None):
+        """
+        add a valid service format using our friendly names
+        :param format:
+        :return:
+        """
         if format is None:
             raise(ValueError('No service format selected'))
         if format not in self.service_formats:
@@ -260,6 +274,13 @@ class RoyalMailBody:
 
 
     def add_service_type(self, service_type=None):
+
+        """
+        add a valid service type using our friendly names
+        :param service_type:
+        :return:
+        """
+
         if service_type is None:
             raise(ValueError('no service type selected'))
 
@@ -270,6 +291,12 @@ class RoyalMailBody:
 
 
     def add_service_offering(self, service_offering=None):
+        """
+        add a valid service offering using our friendly names
+        :param service_offering:
+        :return:
+        """
+
         if service_offering is None:
             raise(ValueError('No service type selected'))
         if service_offering not in self.service_offerings:
@@ -283,6 +310,11 @@ class RoyalMailBody:
 
 
     def add_signature(self, signature=False):
+        """
+        Do we want a signature on delivery
+        :param signature:
+        :return:
+        """
         if isinstance(signature, bool):
             self.signature = signature
         else:
@@ -290,6 +322,11 @@ class RoyalMailBody:
 
 
     def add_service_enhancements(self, enhancement):
+        """
+        add a single service enhancement, can be called multiple times to append required items
+        :param enhancement:
+        :return:
+        """
         if enhancement is None:
             raise(ValueError('No Enhancement Selected'))
         if enhancement not in self.service_enhancements:
@@ -298,6 +335,14 @@ class RoyalMailBody:
 
 
     def add_receipient_contact(self, name, email, complementary_name=None, telephone=None):
+        """
+        Add the name and contact of who this is being sent to
+        :param name:
+        :param email:
+        :param complementary_name:
+        :param telephone:
+        :return:
+        """
         receipient = {
             "name": name,
             "complementaryName": complementary_name,
@@ -309,6 +354,13 @@ class RoyalMailBody:
         self.receipient = receipient
 
     def add_items(self, number, weight, unit_of_measure):
+        """
+        Add items- currently only a single item
+        :param number:
+        :param weight:
+        :param unit_of_measure:
+        :return:
+        """
         items = [{
             "count": number,
             "weight": {
@@ -321,6 +373,19 @@ class RoyalMailBody:
 
     def add_receipient_address(self, address_line1, post_town, county, postcode, country, building_name=None,
                                building_number=None, address_line2=None, address_line3=None):
+        """
+        Add address of receipient
+        :param address_line1:
+        :param post_town:
+        :param county:
+        :param postcode:
+        :param country:
+        :param building_name:
+        :param building_number:
+        :param address_line2:
+        :param address_line3:
+        :return:
+        """
         address = {
             "buildingName": building_name,
             "buildingNumber": building_number,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 
-current_version = 0.0.5
+current_version = 0.0.6
 
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
                   'Documentation': 'http://royal-mail-rest-api.readthedocs.io/en/latest/index.html'},
     download_url='https://github.com/Bobspadger/royal_mail_rest_api',
     url='https://github.com/bobspadger/royal_mail_rest_api',
-    version='0.0.5',
+    version='0.0.6',
     zip_safe=False,
 )


### PR DESCRIPTION
* Issue/7 (#16)

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* version bump 0.0.3

* Add service helpers (#19)

* Issue/7 (#16) (#17)

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* version bump 0.0.3

* ready for 0.0.4

Better way of selecting service options by a friendly name
Added in dictionaries of possible options and the relevant RM codes to send.

all lowercase, spaces replaced with _

* adjust Exception types to be more logical

* remove cli, not using

add in if required later

* fix version

* Bump version: 0.0.3 → 0.0.4

* tox breaking

* tox breaking

* Tests (#23)

* add in defaults of None to some of our service offerings

start some tests

* more tests

add in some better exceptions to the delivery object builder

* Bump version: 0.0.4 → 0.0.5

* Error handling (#25)

* Develop (#24)

* Issue/7 (#16)

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* version bump 0.0.3

* Add service helpers (#19)

* Issue/7 (#16) (#17)

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* issue#7

now stores the time the token was created and re-uses it for 3:45 minutes before requesting a new one.

updated the example file as the manifest info will always change.

* version bump 0.0.3

* ready for 0.0.4

Better way of selecting service options by a friendly name
Added in dictionaries of possible options and the relevant RM codes to send.

all lowercase, spaces replaced with _

* adjust Exception types to be more logical

* remove cli, not using

add in if required later

* fix version

* Bump version: 0.0.3 → 0.0.4

* tox breaking

* tox breaking

* Tests (#23)

* add in defaults of None to some of our service offerings

start some tests

* more tests

add in some better exceptions to the delivery object builder

* Bump version: 0.0.4 → 0.0.5

* fix makefile to build the distribution after the clean step in release otherwise it was just deleting everything it wanted to upload!

* Create a RoyalMailError to raise when we get errors back from RM themselves.
create an error handler to use instead of just raise_for_status so we get a true error back and return the JSON so the requesting application can deal with the exceptions gracefully.

* docs

* Bump version: 0.0.5 → 0.0.6

* docs

* doctrings